### PR TITLE
resolve installation crash on CPU-only/non-GPU environments and update Node to v22 LTS

### DIFF
--- a/DeployWorker.cs
+++ b/DeployWorker.cs
@@ -230,7 +230,7 @@ namespace OpenClawInstaller
                 psiInstall.EnvironmentVariables["PATH"] = customPathEnv;
                 DebugLog(logger, $"[Critical] Setting BUILD_TYPE to: {buildType}");
                 DebugLog(logger, $"执行命令: {psiInstall.FileName} {psiInstall.Arguments}");
-                // ========== 必须新增以下代码（针对虚拟机崩溃的终极杀招） ==========
+                // ========== 针对未检测到 GPU 的环境，强制本地 CPU 编译==========
                 if (buildType == "cpu")
                 {
                  // 彻底禁止 node-llama-cpp 去网上找预编译包和乱摸显卡
@@ -471,6 +471,7 @@ namespace OpenClawInstaller
         }
     }
 }
+
 
 
 


### PR DESCRIPTION
此 PR 解决了在无显卡或纯 CPU 环境下执行 npm install 时由于硬件探测导致的 0xC0000005 (Access Violation) 崩溃问题。

适配纯 CPU 环境安装，解决无 GPU 时的 0xC0000005 报错，修复无 GPU 环境下 node-llama-cpp 的安装崩溃问题，并降级 Node.js 至 v22.13.1 LTS，以提高底层 C++ 原生模块的兼容性与稳定性。优化生成的 start.ps1。
Fixes #3 